### PR TITLE
chore: npm7 compat

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
The peer deps of `@vue/cli-plugin-*` cause npm7 to spin endlessly on
install.

Use a `.npmrc` file to use the npm6 peer dep behaviour to fix this.

**IMPORTANT: Please do not create a Pull Request for this repository.**

## Contributing

Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
4. Push to the Branch (`git push origin feature/amazing-example`)
5. Open a Pull Request
